### PR TITLE
docco fix: digest-spec? had #f where it should have had #t

### DIFF
--- a/crypto-doc/scribblings/digest.scrbl
+++ b/crypto-doc/scribblings/digest.scrbl
@@ -32,7 +32,7 @@ and low-level, incremental operations.
 
 @defproc[(digest-spec? [v any/c]) boolean?]{
 
-Returns @racket[#f] if @racket[v] represents a digest
+Returns @racket[#t] if @racket[v] represents a digest
 specifier, @racket[#f] otherwise.
 
 A digest specifier is a symbol, which is interpreted as the name of a

--- a/crypto-doc/scribblings/digest.scrbl
+++ b/crypto-doc/scribblings/digest.scrbl
@@ -50,7 +50,7 @@ specifiers.
 
 @defproc[(digest-impl? [v any/c]) boolean?]{
 
-Returns @racket[#f] if @racket[v] represents a digest implementation,
+Returns @racket[#t] if @racket[v] represents a digest implementation,
 @racket[#f] otherwise.
 }
 


### PR DESCRIPTION
The docs for digest-spec? said: "Returns #f if v represents a digest specifier, #f otherwise."  Should have had #t in the first position.

