### PR TITLE
cooperate with `raco distribute` to include shared libs in distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  build:
+    name: "Build on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        racket-version: ["stable", "current"]
+        racket-variant: ["BC", "CS"]
+    steps:
+      - uses: actions/checkout@master
+      - uses: Bogdanp/setup-racket@v0.12
+        with:
+          architecture: x64
+          distribution: full
+          variant: ${{ matrix.racket-variant }}
+          version: ${{ matrix.racket-version }}
+      - name: Install library dependencies
+        run: |
+          sudo apt-get update && \
+            sudo apt-get install -y \
+              libargon2-dev \
+              libb2-dev \
+              libsodium-dev \
+              nettle-dev
+      - name: Install the package
+        run: sudo raco pkg install --auto crypto-lib/ crypto-test/ crypto-doc/ crypto/
+      - name: Run the tests
+        run: raco test crypto-test/

--- a/crypto-lib/info.rkt
+++ b/crypto-lib/info.rkt
@@ -2,7 +2,7 @@
 
 ;; pkg info
 
-(define version "1.5")
+(define version "1.6")
 (define collection "crypto")
 (define deps '("base" "asn1-lib" "binaryio-lib" ["gmp-lib" #:version "1.1"]))
 (define pkg-authors '(ryanc))

--- a/crypto-lib/private/argon2/ffi.rkt
+++ b/crypto-lib/private/argon2/ffi.rkt
@@ -26,8 +26,7 @@
 
 ;; Reference: https://github.com/P-H-C/phc-winner-argon2
 
-;; Cooperate with `raco distribute` to include the library in
-;; distributions if present.
+;; Cooperate with `raco distribute`.
 (define-runtime-path libargon2-so
   '(so "libargon2" ("1" "0" #f)))
 

--- a/crypto-lib/private/argon2/ffi.rkt
+++ b/crypto-lib/private/argon2/ffi.rkt
@@ -14,16 +14,26 @@
 ;; along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 #lang racket/base
-(require ffi/unsafe
+
+(require (for-syntax racket/base)
+         ffi/unsafe
          ffi/unsafe/define
-         "../common/ffi.rkt"
-         "../common/error.rkt")
+         racket/runtime-path
+         "../common/error.rkt"
+         "../common/ffi.rkt")
+
 (provide (protect-out (all-defined-out)))
 
 ;; Reference: https://github.com/P-H-C/phc-winner-argon2
 
+;; Cooperate with `raco distribute` to include the library in
+;; distributions if present.
+(define-runtime-path libargon2-so
+  '(so "libargon2" ("1" "0" #f)))
+
 (define-values (libargon2 argon2-load-error)
-  (ffi-lib-or-why-not "libargon2" '("1" "0" #f)))
+  (ffi-lib-or-why-not libargon2-so '("1" "0" #f)))
+
 (define-ffi-definer define-argon2 libargon2
   #:default-make-fail make-not-available)
 

--- a/crypto-lib/private/b2/ffi.rkt
+++ b/crypto-lib/private/b2/ffi.rkt
@@ -27,6 +27,10 @@
 (define-runtime-path libb2-so
   '(so "libb2" ("1" #f)))
 
+;; depended on by libb2-so
+(define-runtime-path libgomp-so
+  '(so "libgomp"))
+
 (define-values (libb2 b2-load-error)
   (ffi-lib-or-why-not libb2-so '("1" #f)))
 

--- a/crypto-lib/private/b2/ffi.rkt
+++ b/crypto-lib/private/b2/ffi.rkt
@@ -14,13 +14,21 @@
 ;; along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 #lang racket/base
-(require ffi/unsafe
+
+(require (for-syntax racket/base)
+         ffi/unsafe
          ffi/unsafe/define
+         racket/runtime-path
          "../common/ffi.rkt")
+
 (provide (protect-out (all-defined-out)))
 
+;; Cooperate with `raco distribute`.
+(define-runtime-path libb2-so
+  '(so "libb2" ("1" #f)))
+
 (define-values (libb2 b2-load-error)
-  (ffi-lib-or-why-not "libb2" '("1" #f)))
+  (ffi-lib-or-why-not libb2-so '("1" #f)))
 
 (define-ffi-definer define-b2 libb2
   #:default-make-fail make-not-available)

--- a/crypto-lib/private/decaf/ffi.rkt
+++ b/crypto-lib/private/decaf/ffi.rkt
@@ -14,13 +14,21 @@
 ;; along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 #lang racket/base
-(require ffi/unsafe
+
+(require (for-syntax racket/base)
+         ffi/unsafe
          ffi/unsafe/define
+         racket/runtime-path
          "../common/ffi.rkt")
+
 (provide (protect-out (all-defined-out)))
 
+;; Cooperate with `raco distribute`.
+(define-runtime-path libdecaf-so
+  '(so "libdecaf"))
+
 (define-values (libdecaf decaf-load-error)
-  (ffi-lib-or-why-not "libdecaf" '(#f)))
+  (ffi-lib-or-why-not libdecaf-so '(#f)))
 
 (define-ffi-definer define-decaf libdecaf
   #:default-make-fail make-not-available)

--- a/crypto-lib/private/gcrypt/ffi.rkt
+++ b/crypto-lib/private/gcrypt/ffi.rkt
@@ -30,6 +30,10 @@
 (define-runtime-path libgcrypt-so
   '(so "libgcrypt" ("20" #f)))
 
+;; depended on by libgcrypt
+(define-runtime-path libgpg-error-so
+  '(so "libgpg-error"))
+
 (define-values (libgcrypt gcrypt-load-error)
   (ffi-lib-or-why-not libgcrypt-so '("20" #f)))
 

--- a/crypto-lib/private/gcrypt/ffi.rkt
+++ b/crypto-lib/private/gcrypt/ffi.rkt
@@ -14,16 +14,24 @@
 ;; along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 #lang racket/base
-(require ffi/unsafe
-         ffi/unsafe/define
+
+(require (for-syntax racket/base)
+         ffi/unsafe
          ffi/unsafe/alloc
          ffi/unsafe/atomic
-         "../common/ffi.rkt"
-         "../common/error.rkt")
+         ffi/unsafe/define
+         racket/runtime-path
+         "../common/error.rkt"
+         "../common/ffi.rkt")
+
 (provide (protect-out (all-defined-out)))
 
+;; Cooperate with `raco distribute`.
+(define-runtime-path libgcrypt-so
+  '(so "libgcrypt" ("20" #f)))
+
 (define-values (libgcrypt gcrypt-load-error)
-  (ffi-lib-or-why-not "libgcrypt" '("20" #f)))
+  (ffi-lib-or-why-not libgcrypt-so '("20" #f)))
 
 (define-ffi-definer define-gcrypt libgcrypt
   #:default-make-fail make-not-available)

--- a/crypto-lib/private/nettle/ffi.rkt
+++ b/crypto-lib/private/nettle/ffi.rkt
@@ -469,8 +469,12 @@
 
 ;; ============================================================
 
+(define-runtime-path libhogweed-so
+  '(so "libhogweed" ("6" "5" "4" #f)))
+
 (define-values (libhogweed hogweed-load-error)
-  (ffi-lib-or-why-not "libhogweed" '("6" "5" "4" #f)))
+  (ffi-lib-or-why-not libhogweed-so '("6" "5" "4" #f)))
+
 (define-ffi-definer define-nettleHW libhogweed
   #:default-make-fail make-not-available)
 

--- a/crypto-lib/private/nettle/ffi.rkt
+++ b/crypto-lib/private/nettle/ffi.rkt
@@ -14,16 +14,24 @@
 ;; along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 #lang racket/base
-(require ffi/unsafe
+
+(require (for-syntax racket/base)
+         ffi/unsafe
          ffi/unsafe/alloc
          (only-in '#%foreign ffi-obj)
          ffi/unsafe/define
          (rename-in gmp/unsafe [_mpz _mpz_t])
+         racket/runtime-path
          "../common/ffi.rkt")
+
 (provide (protect-out (all-defined-out)))
 
+;; Cooperate with `raco distribute`.
+(define-runtime-path libnettle-so
+  '(so "libnettle" ("8" "7" "6" #f)))
+
 (define-values (libnettle nettle-load-error)
-  (ffi-lib-or-why-not "libnettle" '("8" "7" "6" #f)))
+  (ffi-lib-or-why-not libnettle-so '("8" "7" "6" #f)))
 
 (define-ffi-definer define-nettle libnettle
   #:default-make-fail make-not-available)

--- a/crypto-lib/private/sodium/ffi.rkt
+++ b/crypto-lib/private/sodium/ffi.rkt
@@ -14,13 +14,21 @@
 ;; along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 #lang racket/base
-(require ffi/unsafe
+
+(require (for-syntax racket/base)
+         ffi/unsafe
          ffi/unsafe/define
+         racket/runtime-path
          "../common/ffi.rkt")
+
 (provide (protect-out (all-defined-out)))
 
+;; Cooperate with `raco distribute`.
+(define-runtime-path libsodium-so
+  '(so "libsodium" ("23" "18" #f)))
+
 (define-values (libsodium sodium-load-error)
-  (ffi-lib-or-why-not "libsodium" '("23" "18" #f)))
+  (ffi-lib-or-why-not libsodium-so '("23" "18" #f)))
 
 (define-ffi-definer define-na libsodium
   #:default-make-fail make-not-available)


### PR DESCRIPTION
This makes it so that distros built with `raco distribute` include the shared libs they depend on when those libs are installed specifically for Racket (like in the case of my `libargon2` package). 