### PR TITLE
OpenSSL 3 EVP_MD function name changes

### DIFF
--- a/crypto-lib/private/libcrypto/digest.rkt
+++ b/crypto-lib/private/libcrypto/digest.rkt
@@ -27,7 +27,7 @@
     (super-new)
     (inherit get-spec get-size get-block-size sanity-check)
 
-    (sanity-check #:size (EVP_MD_size md) #:block-size (EVP_MD_block_size md))
+    (sanity-check #:size (EVP_MD_get_size md) #:block-size (EVP_MD_get_block_size md))
 
     (define/override (key-size-ok? size) #f)
 

--- a/crypto-lib/private/libcrypto/ffi.rkt
+++ b/crypto-lib/private/libcrypto/ffi.rkt
@@ -218,7 +218,11 @@
         -> _void))
 
 (define-crypto EVP_MD_size (_fun _EVP_MD -> _int))
+(define-crypto EVP_MD_get_size (_fun _EVP_MD -> _int)
+  #:fail (K EVP_MD_size))
 (define-crypto EVP_MD_block_size (_fun _EVP_MD -> _int))
+(define-crypto EVP_MD_get_block_size (_fun _EVP_MD -> _int)
+  #:fail (K EVP_MD_block_size))
 
 ;; New API since 1.1
 (define-crypto EVP_MD_CTX_free (_fun _EVP_MD_CTX -> _void))


### PR DESCRIPTION
I think this can allow the library to use the OpenSSL 3 functions and fall back to an earlier release?